### PR TITLE
Cross-Platform OS Packaging and Publishing to Bintray using Travis & Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+sudo: required
+
+services:
+  - docker
+
+language: go
+go:
+  - 1.8
+
+env:
+  matrix:
+    - GOARCH=amd64 OSARCH=amd64
+    - GOARCH=386 OSARCH=i386
+  global:
+    - APP=${TRAVIS_REPO_SLUG#*/}
+    - APP_SHORT_NAME=jfrog
+    - VERSION=1.10.2
+    - BT_REPO_RPM=public-rpm
+    - BT_REPO_DEB=public-deb
+    - BT_REPO_TARGZ=public-targz
+    - BT_SUBJECT=bincrafters
+    - ORIGINAL_AUTHOR=jfrogdev
+    - DOCKER_IMAGE=bincrafters/go-bin-rpm
+
+before_install:
+  - sudo add-apt-repository 'deb https://dl.bintray.com/bincrafters/public-deb unstable main'
+  - sudo apt-get -qq update
+  - mkdir -p $GOPATH/bin
+  - cd ~
+  - curl https://glide.sh/get | sh
+  - cd $HOME/gopath/src/github.com
+  - mv $BT_SUBJECT $ORIGINAL_AUTHOR
+  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/$ORIGINAL_AUTHOR/$APP
+  
+install:
+  - cd $TRAVIS_BUILD_DIR
+#  - glide install
+#  - go install
+  - sudo apt-get install --allow-unauthenticated fakeroot go-bin-deb changelog
+
+script: 
+  - mkdir -p build/$OSARCH
+  - GOOS=linux GOARCH=$GOARCH go build --ldflags "-X main.VERSION=$VERSION" -o build/$OSARCH/$APP_SHORT_NAME jfrog/main.go
+  - go-bin-deb generate --file deb.json -a $OSARCH --version $VERSION -o $APP-$OSARCH-$VERSION.deb
+  - docker run -v $PWD:/mnt/travis $DOCKER_IMAGE /bin/sh -c "cd /mnt/travis && go-bin-rpm generate --file rpm.json -a $OSARCH --version $VERSION -o $APP-$OSARCH-$VERSION.rpm"
+
+after_success: 
+  -  mv jfrog jfrog_dir
+  -  ln -s build/$OSARCH/jfrog jfrog
+  - ./jfrog bt config --user $BT_USER --key $BT_KEY --licenses MIT
+  - ./jfrog bt upload --override=true --publish=true --deb=unstable/main/$OSARCH $APP-$OSARCH-$VERSION.deb $BT_SUBJECT/$BT_REPO_DEB/$APP/$VERSION pool/j/$APP/
+  - ./jfrog bt upload --override=true --publish=true $APP-$OSARCH-$VERSION.rpm $BT_SUBJECT/$BT_REPO_RPM/$APP/$VERSION
+  #- ./jfrog bt upload --override=true --publish=true $APP-$OSARCH-$VERSION.tar.gz $BT_SUBJECT/$BT_REPO_TARGZ/$APP/$VERSION
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,11 @@ install:
 
 script: 
   - mkdir -p build/$OSARCH
-  - GOOS=linux GOARCH=$GOARCH go build --ldflags "-X main.VERSION=$VERSION" -o build/$OSARCH/$APP_SHORT_NAME jfrog/main.go
+  - GOOS=linux GOARCH=$GOARCH go build --ldflags "-X main.VERSION=$VERSION" -o build/$OSARCH/$APP_SHORT_NAME jfrog-cli/jfrog/main.go
   - go-bin-deb generate --file deb.json -a $OSARCH --version $VERSION -o $APP-$OSARCH-$VERSION.deb
   - docker run -v $PWD:/mnt/travis $DOCKER_IMAGE /bin/sh -c "cd /mnt/travis && go-bin-rpm generate --file rpm.json -a $OSARCH --version $VERSION -o $APP-$OSARCH-$VERSION.rpm"
 
 after_success: 
-  -  mv jfrog jfrog_dir
   -  ln -s build/$OSARCH/jfrog jfrog
   - ./jfrog bt config --user $BT_USER --key $BT_KEY --licenses MIT
   - ./jfrog bt upload --override=true --publish=true --deb=unstable/main/$OSARCH $APP-$OSARCH-$VERSION.deb $BT_SUBJECT/$BT_REPO_DEB/$APP/$VERSION pool/j/$APP/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+image: Visual Studio 2017
+
+clone_folder: c:\gopath\src\github.com\jfrogdev\jfrog-cli-go
+
+environment:
+  APP: jfrog-cli-go
+  APP_SHORT_NAME : jfrog
+  VERSION: 1.10.2
+  MSVC_DEFAULT_OPTIONS : ON
+  BT_REPO_MSI : public-msi
+  BT_REPO_CHOCO : public-choco
+  BT_SUBJECT : bincrafters
+  GOPATH: c:\gopath
+  
+  matrix:
+    - GOARCH: 386
+      
+configuration:
+  - Release
+
+install: 
+  - choco install go-msi
+  - set PATH=%WIX%\bin;C:\PROGRA~1\go-msi;%PATH%
+  - set PATH=%GOPATH%\bin\windows_386;%GOPATH%\bin;c:\go\bin;%PATH%
+#  - go get -u github.com/Masterminds/glide
+#  - glide install
+  
+build_script: 
+  - go build -o %APP_SHORT_NAME%.exe --ldflags "-X main.VERSION=%VERSION%" jfrog/main.go
+  - go-msi make --msi %APPVEYOR_BUILD_FOLDER%\%APP%-%GOARCH%-%VERSION%.msi --version %VERSION% --arch %GOARCH%
+  - go-msi choco --path wix.json --version %VERSION% --input %APP%-%GOARCH%-%VERSION%.msi
+  
+deploy_script:
+  - set VCS_URL=https://github.com/%APPVEYOR_REPO_NAME%
+  - jfrog bt config --user %BT_USER% --key %BT_KEY% --licenses MIT
+  - jfrog bt upload --override=true --publish=true %APP%-%GOARCH%-%VERSION%.msi %BT_SUBJECT%/%BT_REPO_MSI%/%APP%/%VERSION%
+  - jfrog bt upload --override=true --publish=true %APP%.%VERSION%.nupkg %BT_SUBJECT%/%BT_REPO_CHOCO%/%APP%/%VERSION%
+
+   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 #  - glide install
   
 build_script: 
-  - go build -o %APP_SHORT_NAME%.exe --ldflags "-X main.VERSION=%VERSION%" jfrog/main.go
+  - go build -o %APP_SHORT_NAME%.exe --ldflags "-X main.VERSION=%VERSION%" jfrog-cli/jfrog/main.go
   - go-msi make --msi %APPVEYOR_BUILD_FOLDER%\%APP%-%GOARCH%-%VERSION%.msi --version %VERSION% --arch %GOARCH%
   - go-msi choco --path wix.json --version %VERSION% --input %APP%-%GOARCH%-%VERSION%.msi
   

--- a/deb.json
+++ b/deb.json
@@ -1,0 +1,23 @@
+{
+  "name": "jfrog-cli-go",
+  "maintainer": "JFrogDev <support@jfrog.com>",
+  "description": "A CLI client for accessing Artifactory, Bintray and Mission Control",
+  "changelog-cmd": "changelog debian --vars='{\"name\":\"!name!\"}'",
+  "homepage": "http://github.com/jfrogdev/!name!",
+  "files": [
+    {
+      "from": "build/!arch!/jfrog",
+      "to": "/usr/bin",
+      "base" : "build/!arch!/",
+      "fperm": "0755"
+    }
+  ],
+  "copyrights": [
+    {
+      "files": "*",
+      "copyright": "2017 JFrogDev <support@jfrog.com>",
+      "license": "Apache License 2.0",
+      "file": "LICENSE"
+    }
+  ]
+}

--- a/rpm.json
+++ b/rpm.json
@@ -1,0 +1,16 @@
+{
+  "name": "jfrog-cli-go",
+  "summary": "JFrog CLI",
+  "description": "A CLI client for accessing Artifactory, Bintray and Mission Control",
+  "changelog-cmd": "changelog rpm",
+  "license": "LICENSE",
+  "url": "https://github.com/jfrogdev/!name!",
+  "files": [
+    {
+      "from": "build/!arch!/jfrog",
+      "to": "%{_bindir}/",
+      "base": "build/!arch!/",
+      "type": ""
+    }
+  ]
+}

--- a/wix.json
+++ b/wix.json
@@ -1,0 +1,32 @@
+{
+  "product": "jfrog-cli-go",
+  "company": "JFrog",
+  "license": "LICENSE",
+  "upgrade-code": "",
+  "files": {
+    "guid": "",
+    "items": [
+      "jfrog.exe"
+    ]
+  },
+  "env": {
+    "guid": "",
+    "vars": [
+      {
+        "name": "PATH",
+        "value": "[INSTALLDIR]",
+        "permanent": "no",
+        "system": "no",
+        "action": "set",
+        "part": "last"
+      }
+    ]
+  },
+  "shortcuts": {},
+  "choco": {
+    "description": "A CLI client for accessing Artifactory, Bintray and Mission Control",
+    "project-url": "https://github.com/jfrogdev/jfrog-cli-go",
+    "tags": "jfrog, cli",
+    "license-url": "https://github.com/jfrogdev/jfrog-cli-go/blob/master/LICENSE"
+  }
+}


### PR DESCRIPTION
## Introduction 

This pull request is in response to #70 . It contains a LOT of new information, and it will take time and emails or slack chats to digest it all. If you want to create a separate branch for this, I'm happy to resubmit. 

## Packaging

Cross-platform OS packaging with full support for the built-in OS package managers is inherently complicated. Fortunately, one OSS developer went to great lengths to bring it within reach of mortals.  His Github handle is `mh-cbon`, and he created all the tools used for this process. 

At a high level, he defined a fairly standardized JSON schema for each of the three most popular (and wildly different) OS package managers.  He then applied a standardized CLI experience and created corresponding package utilities: `go-msi`, `go-bin-deb`, and `go-bin-rpm`.  The tools read the configs, translate them to the proprietary formats, and then automates the calls to the proprietary package tools behind the scenes.  It's a remarkable achievement.  The best primer is to read about the tools and process detailed here (although our strategy diverges in a few areas):

- https://github.com/mh-cbon/go-github-release

My contribution was to streamline the use of his tools into effective "recipe templates" for publishing his packaging tools to Bintray rather than gh-pages and gh-release. This led me to finding and using `jfrog-go-cli` for the publishing.  I then discovered that `jfrog-cli-go` could benefit from the same workflow, so I ported the templates to here.  It was actually "easy" to port the recipe's from the other repos, which is a testament to the modularity and portability of the strategy.  However, please note, it took actual work weeks to figure the whole strategy out, so "grokking" it all will not be trivial to learn (but at least now it's approachable). 

## Outputs
To see the finished products of the additions made in this PR, you can look at these repositories:

- https://bintray.com/bincrafters/public-choco
- https://bintray.com/bincrafters/public-msi
- https://bintray.com/bincrafters/public-deb
- https://bintray.com/bincrafters/public-rpm

You can intall the CLI from any of these repos using the corresponding package managers. 

First you add the repo to your local list:
- Debian
`echo "deb https://dl.bintray.com/bincrafters/public-deb unstable main" | sudo tee -a /etc/apt/sources.list && sudo apt-get update`

- Redhat/Centos/Fedora
`wget https://bintray.com/bincrafters/public-rpm/rpm -O bintray-bincrafters-public-rpm.repo && sudo mv bintray-bincrafters-public-rpm.repo /etc/yum.repos.d/ && sudo yum update`

- Windows
`choco source add -n=bincrafters -s="https://api.bintray.com/nuget/bincrafters/public-choco"`

Then install:
- Debian
`apt-get install jfrog-cli-go`

- Redhat/Centos/Fedora
`yum install jfrog-cli-go`

- Windows
`choco install jfrog-cli-go`

## Moving Forward
In theory, JFrog should have (or create)  a similar set of public repos for developers to release official JFrog software through (such as jfrog-cli-go). It's kind of madness not to drink your own kool-aid in this case.  So, one reasonable approach to "take over" the recipe's here is to create your own repos and CI accounts, and change all the relevant variables. You could also try to migrate them to Jenkins and go a different appraoch.  I'm happy to help either way. 

Also, you may choose to publish jfrog-cli-go to Chocolatey. I certainly encourage it, and it's very easy once you've published to your own nuget repository once.  You may also want to submit to "apt" and "yum" central repositories, I have never done this, but would be interested in seeing how it goes. I hear it's much more involved than Chocolatey. 

## Outstanding "Nuances"

- Bintray Web API still has a bug, and won't let you overwrite an existing NUGET package file
-- Thus, after the first successful build/publish of .NUGET to bintray, subsequent builds will fail
-- I have opened two tickets for this, one to change JFrog CLI behavior , one to fix the web API
- Nuget (and therefor chocolatey) wants both i386 and amd64 packaged together. 
-- This doesn't fit well with Appveyor Matrix, which wants to build each separately 
-- You may want to modify the build step to compile both in one build, and then package both. 
-- Currently, appveyor creates both MSI, but only creates i386 NUGET package for chocolatey.
- .deb requires "i386" instead of "386", and it's more common, that's why OSARCH && GOARCH
- MAC, there is currently no related solution for MAC packaging or deployment using BREW. Future?
- Travis runs debian, can't build .rpm on debian, we use docker/fedora image on travis to create .rpm. 

Good luck, and feel free to reach out to me via email for extended discussion. 
