### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.10-alpine as builder
+WORKDIR /go/src/github.com/jfrog/jfrog-cli-go
+COPY . /go/src/github.com/jfrog/jfrog-cli-go
+RUN CGO_ENABLED=0 GOOS=linux go build github.com/jfrog/jfrog-cli-go/jfrog-cli/jfrog
+
+FROM alpine:3.7
+RUN apk add --no-cache bash tzdata ca-certificates
+COPY --from=builder /go/src/github.com/jfrog/jfrog-cli-go/jfrog /usr/local/bin/jfrog
+RUN chmod +x /usr/local/bin/jfrog
+
+ENTRYPOINT [ "/usr/local/bin/jfrog" ]
+CMD ["--help"]


### PR DESCRIPTION
The Dockerfile is built on alpine (pretty common for CLIs now) and comes
with bash, tzdata and ca-certs.

Closes #179