### PR TITLE
Ability to specify version with default set to latest

### DIFF
--- a/getCli.sh
+++ b/getCli.sh
@@ -3,23 +3,31 @@
 CLI_OS="na"
 CLI_UNAME="na"
 
+if [ $# -eq 0 ]
+  then
+	VERSION=\$latest
+	echo "Using latest version of jfrog cli"
+  else
+	VERSION=$1
+fi
+
 if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
-    URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-windows-amd64/jfrog.exe?bt_package=jfrog-cli-windows-amd64"
+    URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/${VERSION}/jfrog-cli-windows-amd64/jfrog.exe?bt_package=jfrog-cli-windows-amd64"
     FILE_NAME="jfrog.exe"
 elif $(echo "${OSTYPE}" | grep -q darwin); then
     CLI_OS="mac"
-    URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-mac-386/jfrog?bt_package=jfrog-cli-mac-386"
+    URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/${VERSION}/jfrog-cli-mac-386/jfrog?bt_package=jfrog-cli-mac-386"
     FILE_NAME="jfrog"
 else
     CLI_OS="linux"
     if $(uname -m | grep -q 64); then
         CLI_UNAME="64"
-        URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64"
+        URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/${VERSION}/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64"
         FILE_NAME="jfrog"
     else
         CLI_UNAME="32"
-        URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/\$latest/jfrog-cli-linux-386/jfrog?bt_package=jfrog-cli-linux-386"
+        URL="https://api.bintray.com/content/jfrog/jfrog-cli-go/${VERSION}/jfrog-cli-linux-386/jfrog?bt_package=jfrog-cli-linux-386"
         FILE_NAME="jfrog"
     fi
 fi


### PR DESCRIPTION
In dockerfile, it is recommended to specify a version of tools that need to be installed instead of using latest. 

Updated the script to allow an option to specify a version. 

Usage: cat getCli.sh | sh -s -- 1.16.0 will download 1.16.0 version vs cat getCli.sh | sh that downloads latest. Tested on mac and ubuntu