### PR TITLE
Added support for go modules without slash in the name

### DIFF
--- a/jfrog-cli/artifactory/utils/golang/project/project.go
+++ b/jfrog-cli/artifactory/utils/golang/project/project.go
@@ -213,7 +213,7 @@ func (project *goProject) archiveProject(version string) (string, error) {
 
 // Parse module name from go.mod content.
 func parseModuleName(modContent string) (string, error) {
-	r, err := regexp.Compile(`module ([\w\.@:%_\+-.~#?&]+/.+)`)
+	r, err := regexp.Compile(`module ([\w\.@:%_\+-.~#?&]+/?.+)`)
 	if err != nil {
 		return "", errorutils.CheckError(err)
 	}

--- a/jfrog-cli/artifactory/utils/golang/project/project_test.go
+++ b/jfrog-cli/artifactory/utils/golang/project/project_test.go
@@ -26,3 +26,28 @@ require (
 		t.Errorf("Expected: %s, got: %s.", expected, actual)
 	}
 }
+
+func TestParseModuleNameWithoutSlash(t *testing.T) {
+	content := `
+
+module go4.org
+
+require (
+        github.com/Sirupsen/logrus v1.0.6
+        golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe // indirect
+        golang.org/x/sys v0.0.0-20180802203216-0ffbfd41fbef // indirect
+        rsc.io/quote v1.5.2
+)
+	`
+
+	expected := "go4.org"
+	actual, err := parseModuleName(content)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if actual != expected {
+		t.Errorf("Expected: %s, got: %s.", expected, actual)
+	}
+}


### PR DESCRIPTION
Some go modules don't have a slash (`/`) in their names in the `go.mod` file. One example is `go4.org` module that is being used by `golang.org/x/build`. You can see the `go.mod` file [here](https://github.com/golang/build/blob/1329dced3a4569a7cd5cb59ca5dfb01adf65be2a/go.mod).

The cli is failing to push this dependencies to Artifactory with the following error message:

```
[Error] Module name missing in go.mod file
```

You can use the following steps to reproduce the issue:

```
#!/bin/bash
export GOPATH=<REPLACE_GO_PATH>
export PATH=$PATH:$GOPATH/bin
export GO111MODULE=off
cd $GOPATH
go get go4.org
cd $GOPATH/src/go4.org
git checkout 417644f6feb5 .
export GO111MODULE=on
go mod init go4.org
go mod tidy
jfrog rt gp <REPLACE_GO_REPO> v0.0.0-20180809161055-417644f6feb5 --server-id=<REPLACE_SERVER_ID> --self=true
```

I'm proposing a change in the regex pattern that gets the module name to make the slash optional.
