### PR TITLE
Upload broken symlink fixed

### DIFF
--- a/jfrog-cli/artifactory/commands/buildinfo/adddependencies.go
+++ b/jfrog-cli/artifactory/commands/buildinfo/adddependencies.go
@@ -109,18 +109,18 @@ func prepareArtifactoryParams(specFile spec.File) (*specutils.ArtifactoryCommonP
 
 func getDependenciesBySpecFileParams(addDepsParams *specutils.ArtifactoryCommonParams) ([]string, error) {
 	addDepsParams.SetPattern(clientutils.ReplaceTildeWithUserHome(addDepsParams.GetPattern()))
-	rootPath, err := fspatterns.GetRootPath(addDepsParams.GetPattern(), addDepsParams.IsRegexp())
+	rootPath, err := fspatterns.GetRootPath(addDepsParams.GetPattern(), addDepsParams.IsRegexp(), false)
 	if err != nil {
 		return nil, err
 	}
 
-	isDir, err := fileutils.IsDir(rootPath)
+	isDir, err := fileutils.IsDir(false, rootPath)
 	if err != nil {
 		return nil, err
 	}
 
 	if !isDir || fileutils.IsPathSymlink(addDepsParams.GetPattern()) {
-		return []string{fspatterns.GetSingleFileToUpload(rootPath, "", false).LocalPath}, nil
+		return []string{fspatterns.GetSingleFileToUpload(rootPath, "", false, false).LocalPath}, nil
 	}
 	return collectPatternMatchingFiles(addDepsParams, rootPath)
 }

--- a/jfrog-cli/artifactory/commands/config.go
+++ b/jfrog-cli/artifactory/commands/config.go
@@ -151,7 +151,7 @@ func readSshKeyPathFromConsole(details, savedDetails *config.ArtifactoryDetails)
 	}
 
 	details.SshKeyPath = clientutils.ReplaceTildeWithUserHome(details.SshKeyPath)
-	exists, err := fileutils.IsFileExists(details.SshKeyPath)
+	exists, err := fileutils.IsFileExists(false, details.SshKeyPath)
 	if err != nil {
 		return err
 	}

--- a/jfrog-cli/artifactory/commands/gradle/gradle.go
+++ b/jfrog-cli/artifactory/commands/gradle/gradle.go
@@ -1,9 +1,10 @@
 package gradle
 
 import (
+	"fmt"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
+	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -14,7 +15,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"fmt"
 )
 
 const gradleExtractorDependencyVersion = "4.7.5"
@@ -91,7 +91,7 @@ func getInitScript(gradleDependenciesDir, gradlePluginFilename string) (string, 
 	}
 	initScriptPath := filepath.Join(gradleDependenciesDir, gradleInitScriptTemplate)
 
-	exists, err := fileutils.IsFileExists(initScriptPath)
+	exists, err := fileutils.IsFileExists(false, initScriptPath)
 	if exists || err != nil {
 		return initScriptPath, err
 	}
@@ -99,7 +99,7 @@ func getInitScript(gradleDependenciesDir, gradlePluginFilename string) (string, 
 	gradlePluginPath := filepath.Join(gradleDependenciesDir, gradlePluginFilename)
 	gradlePluginPath = strings.Replace(gradlePluginPath, "\\", "\\\\", -1)
 	initScriptContent := strings.Replace(utils.GradleInitScript, "${pluginLibDir}", gradlePluginPath, -1)
-	if !fileutils.IsPathExists(gradleDependenciesDir) {
+	if !fileutils.IsPathExists(false, gradleDependenciesDir) {
 		err = os.MkdirAll(gradleDependenciesDir, 0777)
 		if errorutils.CheckError(err) != nil {
 			return "", err

--- a/jfrog-cli/artifactory/commands/mvn/mvn.go
+++ b/jfrog-cli/artifactory/commands/mvn/mvn.go
@@ -2,6 +2,7 @@ package mvn
 
 import (
 	"errors"
+	"fmt"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -15,7 +16,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"fmt"
 )
 
 const mavenExtractorDependencyVersion = "2.11.1"
@@ -80,7 +80,7 @@ func downloadDependencies() (string, error) {
 func createClassworldsConfig(dependenciesPath string) error {
 	classworldsPath := filepath.Join(dependenciesPath, ClasswordConfFileName)
 
-	if fileutils.IsPathExists(classworldsPath) {
+	if fileutils.IsPathExists(false, classworldsPath) {
 		return nil
 	}
 	return errorutils.CheckError(ioutil.WriteFile(classworldsPath, []byte(utils.ClassworldsConf), 0644))

--- a/jfrog-cli/artifactory/utils/buildinfoproperties_test.go
+++ b/jfrog-cli/artifactory/utils/buildinfoproperties_test.go
@@ -109,7 +109,7 @@ func TestGeneratedBuildInfoFile(t *testing.T) {
 	if !actualConfig.IsSet(generatedBuildInfoKey) {
 		t.Error(generatedBuildInfoKey, "key does not exists")
 	}
-	if !fileutils.IsPathExists(actualConfig.GetString(generatedBuildInfoKey)) {
+	if !fileutils.IsPathExists(false, actualConfig.GetString(generatedBuildInfoKey)) {
 		t.Error("Path: ", actualConfig.GetString(generatedBuildInfoKey), "does not exists")
 	}
 	defer os.Remove(actualConfig.GetString(generatedBuildInfoKey))

--- a/jfrog-cli/artifactory/utils/buildutils.go
+++ b/jfrog-cli/artifactory/utils/buildutils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
+	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -15,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 )
 
 const BuildInfoDetails = "details"
@@ -113,7 +113,7 @@ func SaveBuildGeneralDetails(buildName, buildNumber string) error {
 	}
 	detailsFilePath := filepath.Join(partialsBuildDir, BuildInfoDetails)
 	var exists bool
-	exists, err = fileutils.IsFileExists(detailsFilePath)
+	exists, err = fileutils.IsFileExists(false, detailsFilePath)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func GetGeneratedBuildsInfo(buildName, buildNumber string) ([]*buildinfo.BuildIn
 
 	var generatedBuildsInfo []*buildinfo.BuildInfo
 	for _, buildFile := range buildFiles {
-		dir, err := fileutils.IsDir(buildFile)
+		dir, err := fileutils.IsDir(false, buildFile)
 		if err != nil {
 			return nil, err
 		}
@@ -186,7 +186,7 @@ func ReadPartialBuildInfoFiles(buildName, buildNumber string) (buildinfo.Partial
 		return nil, err
 	}
 	for _, buildFile := range buildFiles {
-		dir, err := fileutils.IsDir(buildFile)
+		dir, err := fileutils.IsDir(false, buildFile)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +228,7 @@ func RemoveBuildDir(buildName, buildNumber string) error {
 	if err != nil {
 		return err
 	}
-	exists, err := fileutils.IsDirExists(tempDirPath)
+	exists, err := fileutils.IsDirExists(false, tempDirPath)
 	if err != nil {
 		return err
 	}

--- a/jfrog-cli/artifactory/utils/dependenciesutils.go
+++ b/jfrog-cli/artifactory/utils/dependenciesutils.go
@@ -16,7 +16,7 @@ import (
 // targetPath: local download target path.
 func DownloadFromBintrayIfNeeded(downloadPath, filename, targetPath string) error {
 	targetFile := filepath.Join(targetPath, filename)
-	exists, err := fileutils.IsFileExists(targetFile)
+	exists, err := fileutils.IsFileExists(false, targetFile)
 	if exists || err != nil {
 		return err
 	}

--- a/jfrog-cli/artifactory/utils/golang/project/dependencies/dependencies.go
+++ b/jfrog-cli/artifactory/utils/golang/project/dependencies/dependencies.go
@@ -172,7 +172,7 @@ func getPackageZipLocation(cachePath, dependencyName, version string) (string, e
 // Validates if the package zip file exists.
 func getPackagePathIfExists(cachePath, dependencyName, version string) (zipPath string, err error) {
 	zipPath = filepath.Join(cachePath, dependencyName, "@v", version+".zip")
-	fileExists, err := fileutils.IsFileExists(zipPath)
+	fileExists, err := fileutils.IsFileExists(false, zipPath)
 	if err != nil {
 		log.Warn(fmt.Sprintf("Could not find zip binary for dependency '%s' at %s.", dependencyName, zipPath))
 		return "", err

--- a/jfrog-cli/artifactory/utils/nuget/dependencies/assetsjson.go
+++ b/jfrog-cli/artifactory/utils/nuget/dependencies/assetsjson.go
@@ -2,6 +2,7 @@ package dependencies
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -10,7 +11,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
-	"errors"
 )
 
 var assetsFilePath = filepath.Join("obj", "project.assets.json")
@@ -27,7 +27,7 @@ type assetsExtractor struct {
 
 func (extractor *assetsExtractor) IsCompatible(projectName, projectRoot string) (bool, error) {
 	assetsFilePath := filepath.Join(projectRoot, assetsFilePath)
-	exists, err := fileutils.IsFileExists(assetsFilePath)
+	exists, err := fileutils.IsFileExists(false, assetsFilePath)
 	if exists {
 		log.Debug("Found", assetsFilePath, "file for project:", projectName)
 		return true, err
@@ -99,7 +99,7 @@ func (assets *assets) getAllDependencies() (map[string]*buildinfo.Dependency, er
 			return nil, err
 		}
 		nupkgFilePath := filepath.Join(packagesPath, library.Path, nupkgFileName)
-		exists, err := fileutils.IsFileExists(nupkgFilePath)
+		exists, err := fileutils.IsFileExists(false, nupkgFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/jfrog-cli/artifactory/utils/nuget/dependencies/packagesconfig.go
+++ b/jfrog-cli/artifactory/utils/nuget/dependencies/packagesconfig.go
@@ -30,7 +30,7 @@ type packagesExtractor struct {
 
 func (extractor *packagesExtractor) IsCompatible(projectName, projectRoot string) (bool, error) {
 	packagesConfigPath := filepath.Join(projectRoot, packagesFilePath)
-	exists, err := fileutils.IsFileExists(packagesConfigPath)
+	exists, err := fileutils.IsFileExists(false, packagesConfigPath)
 	if exists {
 		log.Debug("Found", packagesConfigPath, "file for project:", projectName)
 		return true, err
@@ -108,7 +108,7 @@ func createAlternativeVersionForms(originalVersion string) []string {
 
 	var alternativeVersions []string
 
-	for i := 4; i > 0 ; i-- {
+	for i := 4; i > 0; i-- {
 		version := strings.Join(versionSlice[:i], ".")
 		if version != originalVersion {
 			alternativeVersions = append(alternativeVersions, version)
@@ -191,7 +191,7 @@ func searchRootDependencies(dfsHelper map[string]*dfsHelper, currentId string, a
 func createNugetPackage(packagesPath string, nuget xmlPackage, nPackage *nugetPackage) (*nugetPackage, error) {
 	nupkgPath := filepath.Join(packagesPath, nPackage.id, nPackage.version, strings.Join([]string{nPackage.id, nPackage.version, "nupkg"}, "."))
 
-	exists, err := fileutils.IsFileExists(nupkgPath)
+	exists, err := fileutils.IsFileExists(false, nupkgPath)
 
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (extractor *packagesExtractor) getGlobalPackagesCache() (string, error) {
 	}
 
 	globalPackagesPath := strings.TrimSpace(strings.TrimPrefix(string(output), "global-packages:"))
-	exists, err := fileutils.IsDirExists(globalPackagesPath)
+	exists, err := fileutils.IsDirExists(false, globalPackagesPath)
 	if err != nil {
 		return "", err
 	}

--- a/jfrog-cli/artifactory/utils/prompt/promptutils.go
+++ b/jfrog-cli/artifactory/utils/prompt/promptutils.go
@@ -34,7 +34,7 @@ func (server *ServerConfig) Set(config *viper.Viper) error {
 }
 
 func VerifyConfigFile(configFilePath string) error {
-	exists, err := fileutils.IsFileExists(configFilePath)
+	exists, err := fileutils.IsFileExists(false, configFilePath)
 	if err != nil {
 		return err
 	}

--- a/jfrog-cli/jfrog/buildtools_test.go
+++ b/jfrog-cli/jfrog/buildtools_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/spec"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/jfrog/inttestutils"
+	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/ioutils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/tests"
-	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	rtutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -628,7 +628,7 @@ func createNpmProject(t *testing.T, dir string) string {
 	}
 
 	// failure can be ignored
-	npmrcExists, err := fileutils.IsFileExists(filepath.Join(filepath.Dir(srcPackageJson), ".npmrc"))
+	npmrcExists, err := fileutils.IsFileExists(false, filepath.Join(filepath.Dir(srcPackageJson), ".npmrc"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/jfrog-cli/missioncontrol/commands/services/attachlic.go
+++ b/jfrog-cli/missioncontrol/commands/services/attachlic.go
@@ -6,13 +6,13 @@ import (
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/missioncontrol/utils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
+	"github.com/jfrog/jfrog-client-go/httpclient"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"github.com/jfrog/jfrog-client-go/httpclient"
 )
 
 func AttachLic(service_name string, flags *AttachLicFlags) error {
@@ -91,7 +91,7 @@ func prepareLicenseFile(filepath string, overrideFile bool) (err error) {
 		return
 	}
 	var dir bool
-	dir, err = fileutils.IsDir(filepath)
+	dir, err = fileutils.IsDir(false, filepath)
 	if err != nil {
 		return
 	}
@@ -102,7 +102,7 @@ func prepareLicenseFile(filepath string, overrideFile bool) (err error) {
 		}
 	}
 	var exists bool
-	exists, err = fileutils.IsFileExists(filepath)
+	exists, err = fileutils.IsFileExists(false, filepath)
 	if err != nil {
 		return
 	}
@@ -113,7 +113,7 @@ func prepareLicenseFile(filepath string, overrideFile bool) (err error) {
 		}
 	}
 	_, directory := fileutils.GetFileAndDirFromPath(filepath)
-	isPathExists := fileutils.IsPathExists(directory)
+	isPathExists := fileutils.IsPathExists(false, directory)
 	if !isPathExists {
 		os.MkdirAll(directory, 0700)
 	}

--- a/jfrog-cli/utils/config/config.go
+++ b/jfrog-cli/utils/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"github.com/buger/jsonparser"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
@@ -17,7 +18,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"fmt"
 )
 
 // This is the default server id. It is used when adding a server config without providing a server ID
@@ -194,7 +194,7 @@ func readConf() (*ConfigV1, error) {
 		return nil, err
 	}
 	config := new(ConfigV1)
-	exists, err := fileutils.IsFileExists(confFilePath)
+	exists, err := fileutils.IsFileExists(false, confFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ type ArtifactoryDetails struct {
 	ServerId       string            `json:"serverId,omitempty"`
 	IsDefault      bool              `json:"isDefault,omitempty"`
 	// Deprecated, use password option instead.
-	ApiKey         string            `json:"apiKey,omitempty"`
+	ApiKey string `json:"apiKey,omitempty"`
 }
 
 type BintrayDetails struct {

--- a/jfrog-cli/utils/lock/lock.go
+++ b/jfrog-cli/utils/lock/lock.go
@@ -75,7 +75,7 @@ func (lock *Lock) createLockDirWithPermissions() (string, error) {
 	}
 	// The lock created in the lock folder within JFrog CLI Home Dir
 	folderName := filepath.Join(homeDir, "lock")
-	exists, err := fileutils.IsDirExists(folderName)
+	exists, err := fileutils.IsDirExists(false, folderName)
 	if !exists {
 		err = fileutils.CreateDirIfNotExist(folderName)
 		if err != nil {
@@ -138,7 +138,7 @@ func (lock *Lock) Lock() error {
 // Or the process that created the lock still running.
 func (lock *Lock) removeOtherLockOrWait(otherLock Lock, filesList *[]string) error {
 	// Check if file exists.
-	exists, err := fileutils.IsFileExists(otherLock.fileName)
+	exists, err := fileutils.IsFileExists(false, otherLock.fileName)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (lock *Lock) getLocks(filesList []string) (Locks, error) {
 // Removes the lock file so other process can continue.
 func (lock *Lock) Unlock() error {
 	log.Debug("Releasing lock: ", lock.fileName)
-	exists, err := fileutils.IsFileExists(lock.fileName)
+	exists, err := fileutils.IsFileExists(false, lock.fileName)
 	if err != nil {
 		return err
 	}

--- a/jfrog-cli/utils/lock/lock_test.go
+++ b/jfrog-cli/utils/lock/lock_test.go
@@ -109,7 +109,7 @@ func TestUnlock(t *testing.T) {
 		t.Error(err)
 	}
 
-	exists, err := fileutils.IsFileExists(lock.fileName)
+	exists, err := fileutils.IsFileExists(false, lock.fileName)
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,7 +120,7 @@ func TestUnlock(t *testing.T) {
 
 	lock.Unlock()
 
-	exists, err = fileutils.IsFileExists(lock.fileName)
+	exists, err = fileutils.IsFileExists(false, lock.fileName)
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,7 +134,7 @@ func TestCreateFile(t *testing.T) {
 	pid := os.Getpid()
 	lock, folderName := getLock(pid, t)
 
-	exists, err := fileutils.IsFileExists(lock.fileName)
+	exists, err := fileutils.IsFileExists(false, lock.fileName)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/jfrog-cli/utils/tests/utils.go
+++ b/jfrog-cli/utils/tests/utils.go
@@ -6,8 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/commands/generic"
-	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/ioutils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
+	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/ioutils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -62,7 +62,7 @@ func init() {
 }
 
 func CleanFileSystem() {
-	isExist, err := fileutils.IsDirExists(Out)
+	isExist, err := fileutils.IsDirExists(false, Out)
 	if err != nil {
 		log.Error(err)
 	}
@@ -179,7 +179,7 @@ func getFileByOs(fileName string) string {
 
 func GetFilePath(fileName string) string {
 	filePath := GetTestResourcesPath() + "specs/common" + fileutils.GetFileSeparator() + fileName
-	isExists, _ := fileutils.IsFileExists(filePath)
+	isExists, _ := fileutils.IsFileExists(false, filePath)
 	if isExists {
 		return filePath
 	}


### PR DESCRIPTION
Fixed jfrog-cli-go #229 

Added the ability to upload broken symlinks with --symlinks=true.

Fixed an issue where when --symlinks=false, the symlink target would be uploaded given the symlink name instead of the target name.

This pull request has a matching pull request in jfrog-client-go.