### PR TITLE
New environment variable, JFROG_CLI_HOME_DIR, to replace JFROG_CLI_HOME

### DIFF
--- a/jfrog-cli/docs/common/help.go
+++ b/jfrog-cli/docs/common/help.go
@@ -13,7 +13,7 @@ const GlobalEnvVars string = `	JFROG_CLI_LOG_LEVEL
 		To avoid having automation scripts interrupted, set this value to false, and instead,
 		provide product server details using the config command.
 
-	JFROG_CLI_HOME
+	JFROG_CLI_HOME_DIR
 		[Default: ~/.jfrog]
 		Defines the JFrog CLI home directory path.
 		`

--- a/jfrog-cli/jfrog/artifactory_test.go
+++ b/jfrog-cli/jfrog/artifactory_test.go
@@ -448,7 +448,7 @@ func TestArtifactorySelfSignedCert(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(path)
-	os.Setenv("JFROG_CLI_HOME", path)
+	os.Setenv(config.JfrogHomeDirEnv, path)
 	os.Setenv(tests.HttpsProxyEnvVar, "1024")
 	go cliproxy.StartLocalReverseHttpProxy(artifactoryDetails.Url)
 
@@ -2371,7 +2371,7 @@ func cleanArtifactoryTest() {
 	if !*tests.TestArtifactory {
 		return
 	}
-	os.Unsetenv(config.JfrogHomeEnv)
+	os.Unsetenv(config.JfrogHomeDirEnv)
 	log.Info("Cleaning test data...")
 	cleanArtifactory()
 	tests.CleanFileSystem()

--- a/jfrog-cli/jfrog/buildtools_test.go
+++ b/jfrog-cli/jfrog/buildtools_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/spec"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/jfrog/inttestutils"
+	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/ioutils"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/tests"
-	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	rtutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -53,7 +53,10 @@ func CleanBuildToolsTests() {
 func createJfrogHomeConfig(t *testing.T) {
 	templateConfigPath := filepath.Join(tests.GetTestResourcesPath(), "configtemplate", config.JfrogConfigFile)
 
-	err := os.Setenv(config.JfrogHomeEnv, filepath.Join(tests.Out, "jfroghome"))
+	err := os.Setenv(config.JfrogHomeDirEnv, filepath.Join(tests.Out, "jfroghome"))
+	if err != nil {
+		t.Error(err)
+	}
 	jfrogHomePath, err := config.GetJfrogHomeDir()
 	if err != nil {
 		t.Error(err)
@@ -669,7 +672,7 @@ func prepareArtifactoryForNpmBuild(t *testing.T, workingDirectory string) {
 
 func cleanBuildToolsTest() {
 	if *tests.TestBuildTools || *tests.TestGo || *tests.TestNuget {
-		os.Unsetenv(config.JfrogHomeEnv)
+		os.Unsetenv(config.JfrogHomeDirEnv)
 		cleanArtifactory()
 		tests.CleanFileSystem()
 	}

--- a/jfrog-cli/jfrog/unit_test.go
+++ b/jfrog-cli/jfrog/unit_test.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/config"
+	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/tests"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	clientTests "github.com/jfrog/jfrog-client-go/utils/tests"
 	"os"
 	"path/filepath"
 	"testing"
-	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/tests"
 )
 
 const (
@@ -30,7 +30,7 @@ func TestUnitTests(t *testing.T) {
 }
 
 func setJfrogHome(homePath string) {
-	if err := os.Setenv(config.JfrogHomeEnv, homePath); err != nil {
+	if err := os.Setenv(config.JfrogHomeDirEnv, homePath); err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}
@@ -38,7 +38,7 @@ func setJfrogHome(homePath string) {
 
 func cleanUnitTestsJfrogHome(homePath string) {
 	os.RemoveAll(homePath)
-	if err := os.Unsetenv(config.JfrogHomeEnv); err != nil {
+	if err := os.Unsetenv(config.JfrogHomeDirEnv); err != nil {
 		os.Exit(1)
 	}
 }

--- a/jfrog-cli/utils/config/config.go
+++ b/jfrog-cli/utils/config/config.go
@@ -22,12 +22,12 @@ import (
 
 // This is the default server id. It is used when adding a server config without providing a server ID
 const (
-	DefaultServerId = "Default-Server"
-	JfrogHomeDirEnv = "JFROG_CLI_HOME_DIR"
-	JfrogHomeEnv    = "JFROG_CLI_HOME" // Old environment variable.
-	// Only used to support users relying on it before introducing JfrogHomeDirEnv
+	DefaultServerId   = "Default-Server"
+	JfrogHomeDirEnv   = "JFROG_CLI_HOME_DIR"
 	JfrogConfigFile   = "jfrog-cli.conf"
 	JfrogDependencies = "dependencies"
+	// Deprecated:
+	JfrogHomeEnv = "JFROG_CLI_HOME"
 )
 
 func IsArtifactoryConfExists() (bool, error) {
@@ -241,25 +241,22 @@ func convertIfNecessary(content []byte) ([]byte, error) {
 }
 
 func GetJfrogHomeDir() (string, error) {
-	// If JfrogHomeDirEnv exists, use it.
-	// Else if JfrogHomeEnv exists, use it by adding .jfrog at the end.
-	// The second variable was left only to support users relying on it before introducing JfrogHomeDirEnv,
-	// shouldn't be used otherwise.
 
+	// The JfrogHomeEnv environment variable has been deprecated and replaced with JfrogHomeDirEnv
 	if os.Getenv(JfrogHomeDirEnv) != "" {
 		return os.Getenv(JfrogHomeDirEnv), nil
 	} else if os.Getenv(JfrogHomeEnv) != "" {
 		return path.Join(os.Getenv(JfrogHomeEnv), ".jfrog"), nil
 	}
 
-	userDir := fileutils.GetHomeDir()
-	if userDir == "" {
+	userHomeDir := fileutils.GetHomeDir()
+	if userHomeDir == "" {
 		err := errorutils.CheckError(errors.New("Couldn't find home directory. Make sure your HOME environment variable is set."))
 		if err != nil {
 			return "", err
 		}
 	}
-	return filepath.Join(userDir, ".jfrog"), nil
+	return filepath.Join(userHomeDir, ".jfrog"), nil
 }
 
 func GetJfrogDependenciesPath() (string, error) {

--- a/jfrog-cli/utils/config/config.go
+++ b/jfrog-cli/utils/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"github.com/buger/jsonparser"
 	"github.com/jfrog/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
@@ -17,13 +18,14 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"fmt"
 )
 
 // This is the default server id. It is used when adding a server config without providing a server ID
 const (
-	DefaultServerId   = "Default-Server"
-	JfrogHomeEnv      = "JFROG_CLI_HOME"
+	DefaultServerId = "Default-Server"
+	JfrogHomeDirEnv = "JFROG_CLI_HOME_DIR"
+	JfrogHomeEnv    = "JFROG_CLI_HOME" // Old environment variable.
+	// Only used to support users relying on it before introducing JfrogHomeDirEnv
 	JfrogConfigFile   = "jfrog-cli.conf"
 	JfrogDependencies = "dependencies"
 )
@@ -239,7 +241,14 @@ func convertIfNecessary(content []byte) ([]byte, error) {
 }
 
 func GetJfrogHomeDir() (string, error) {
-	if os.Getenv(JfrogHomeEnv) != "" {
+	// If JfrogHomeDirEnv exists, use it.
+	// Else if JfrogHomeEnv exists, use it by adding .jfrog at the end.
+	// The second variable was left only to support users relying on it before introducing JfrogHomeDirEnv,
+	// shouldn't be used otherwise.
+
+	if os.Getenv(JfrogHomeDirEnv) != "" {
+		return os.Getenv(JfrogHomeDirEnv), nil
+	} else if os.Getenv(JfrogHomeEnv) != "" {
 		return path.Join(os.Getenv(JfrogHomeEnv), ".jfrog"), nil
 	}
 
@@ -305,7 +314,7 @@ type ArtifactoryDetails struct {
 	ServerId       string            `json:"serverId,omitempty"`
 	IsDefault      bool              `json:"isDefault,omitempty"`
 	// Deprecated, use password option instead.
-	ApiKey         string            `json:"apiKey,omitempty"`
+	ApiKey string `json:"apiKey,omitempty"`
 }
 
 type BintrayDetails struct {


### PR DESCRIPTION
Introduced a new environment variable to replace JFROG_CLI_HOME that was misinterpreted (#172).
Only the new environment variable should be used, however the old one is still supported (so that the cli won't break for users that rely on the old var).