### PR TITLE
Build info wrong artifact name - bug fix

### DIFF
--- a/jfrog-cli/artifactory/commands/generic/download.go
+++ b/jfrog-cli/artifactory/commands/generic/download.go
@@ -72,8 +72,8 @@ func Download(downloadSpec *spec.SpecFiles, configuration *DownloadConfiguration
 		return totalExpected, 0, err
 	}
 	log.Debug("Downloaded", strconv.Itoa(len(filesInfo)), "artifacts.")
-	buildDependencies := convertFileInfoToBuildDependencies(filesInfo)
 	if isCollectBuildInfo {
+		buildDependencies := convertFileInfoToBuildDependencies(filesInfo)
 		populateFunc := func(partial *buildinfo.Partial) {
 			partial.Dependencies = buildDependencies
 		}
@@ -89,6 +89,7 @@ func convertFileInfoToBuildDependencies(filesInfo []clientutils.FileInfo) []buil
 		dependency := buildinfo.Dependency{Checksum: &buildinfo.Checksum{}}
 		dependency.Md5 = fileInfo.Md5
 		dependency.Sha1 = fileInfo.Sha1
+		// Artifact name in build info as the name in artifactory
 		filename, _ := fileutils.GetFileAndDirFromPath(fileInfo.ArtifactoryPath)
 		dependency.Id = filename
 		buildDependecies[i] = dependency

--- a/jfrog-cli/artifactory/commands/generic/upload.go
+++ b/jfrog-cli/artifactory/commands/generic/upload.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	clientutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"os"
 	"strconv"
@@ -101,12 +100,7 @@ func Upload(uploadSpec *spec.SpecFiles, flags *UploadConfiguration) (successCoun
 func convertFileInfoToBuildArtifacts(filesInfo []clientutils.FileInfo) []buildinfo.Artifact {
 	buildArtifacts := make([]buildinfo.Artifact, len(filesInfo))
 	for i, fileInfo := range filesInfo {
-		artifact := buildinfo.Artifact{Checksum: &buildinfo.Checksum{}}
-		artifact.Sha1 = fileInfo.Sha1
-		artifact.Md5 = fileInfo.Md5
-		filename, _ := fileutils.GetFileAndDirFromPath(fileInfo.LocalPath)
-		artifact.Name = filename
-		buildArtifacts[i] = artifact
+		buildArtifacts[i] = fileInfo.ToBuildArtifacts()
 	}
 	return buildArtifacts
 }


### PR DESCRIPTION
Fixed the following issues:

- Artifact's local path was constructed incorrectly.
- The artifact's file name for build info was taken from local path instead of artifactory path.

This pull requests has a complementing one in jfrog-client-go