### PR TITLE
Use replacement dependencies if they exist when running 'go list'

### DIFF
--- a/jfrog-cli/artifactory/utils/golang/project/dependencies/dependencies.go
+++ b/jfrog-cli/artifactory/utils/golang/project/dependencies/dependencies.go
@@ -64,7 +64,7 @@ func getDependencies(cachePath string) ([]Dependency, error) {
 		return nil, err
 	}
 	goCmd.Command = []string{"list"}
-	goCmd.CommandFlags = []string{"-m", "all"}
+	goCmd.CommandFlags = []string{"-m", "-f", "{{or .Replace .String}}", "all"}
 	output, err := utils.RunCmdOutput(goCmd)
 	if err != nil {
 		return nil, errorutils.CheckError(err)


### PR DESCRIPTION
Fixes #262 