### PR TITLE
https_proxy fix for download behind a web proxy on CI machines

### DIFF
--- a/npm/init.js
+++ b/npm/init.js
@@ -17,36 +17,28 @@ function validateNpmVersion() {
     }
 }
 
-function redirectDetectDownload(starturl) {
+function download(url) {
+    // We detect proxy by looking at the environment variable
     if(process.env.https_proxy && process.env.https_proxy.length > 0) {
-        var mainurl = process.env.https_proxy + starturl.replace('https://', '/https/');
-        console.log(mainurl);
-        http.get(mainurl, function(res) {
-            if(res.statusCode == 302) {
-                redirectDetectDownload(res.headers.location);
-            } else if (res.statusCode == 200) {
-                writeToFile(res)
-            } else {
-                console.log('Unexpected status code during JFrog CLI download')
-            }
-        }).on('error', function (err) {console.error(err);});
-    } else {
-        https.get(starturl, function(res) {
-            if(res.statusCode == 302) {
-                redirectDetectDownload(res.headers.location);
-            } else if (res.statusCode == 200) {
-                writeToFile(res)
-            } else {
-                console.log('Unexpected status code during JFrog CLI download')
-            }
-        }).on('error', function (err) {console.error(err);});
+        url = process.env.https_proxy + starturl.replace('https://', '/https/');
     }
+
+    https.get(url, function(res) {
+        if(res.statusCode == 301 || res.statusCode == 302) {
+            download(res.headers.location);
+        } else if (res.statusCode == 200) {
+            writeToFile(res)
+        } else {
+            console.log('Unexpected status code during JFrog CLI download')
+        }
+    }).on('error', function (err) {console.error(err);});
+
 }
 
 function downloadCli() {
     console.log("Downloading JFrog CLI " + version );
     var startUrl = 'https://api.bintray.com/content/jfrog/jfrog-cli-go/' + version + '/' + btPackage + '/' + fileName + '?bt_package=' + btPackage;
-    redirectDetectDownload(startUrl);
+    download(startUrl);
 }
 
 function isValidNpmVersion() {

--- a/npm/package.json
+++ b/npm/package.json
@@ -20,11 +20,9 @@
   },
   "dependencies": {
     "debug": "3.1.0",
-    "follow-redirects": "1.2.6",
     "ms": "2.0.0"
   },
   "bundledDependencies": [
-    "follow-redirects",
     "ms",
     "debug"
   ],


### PR DESCRIPTION
Dear jfrog team. 

This fix will allow CI machines that only have access to the internet over a enterprise proxy to use the npm package.

If you have questions please do not hesitate to ask. I will post a temporary npm package on jfrog-cli-go-proxy. 

kind regards,
Roland