### PR TITLE
Fix bintray access-keys --api-only argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 *.iml
 testsdata/go/project1/go.sum
+
+# vim
+*~
+*.swp

--- a/bintray/cli.go
+++ b/bintray/cli.go
@@ -1151,7 +1151,7 @@ func createAccessKeysParams(c *cli.Context, org, keyId string) *accesskeys.Param
 	params.ExistenceCheckCache = cachePeriod
 	params.WhiteCidrs = c.String("white-cidrs")
 	params.BlackCidrs = c.String("black-cidrs")
-	params.ApiOnly = c.BoolT("recursive")
+	params.ApiOnly = c.BoolT("api-only")
 
 	return params
 }


### PR DESCRIPTION
The `jfrog bt access-keys --api-only` argument was not being set correctly and was instead trying to get its state from a non-existant `recursive` flag. This means that any keys created via `jfrog bt access-keys` also allowed access via non-API means.

This PR fixes the issue so that the `--api-only` flag works correctly and the default setting should once again be `--api-only=true` as the `--help` document suggests.

We also add some `vim` files to the `.gitignore`.